### PR TITLE
Fast error computations

### DIFF
--- a/src/matcouply/conftest.py
+++ b/src/matcouply/conftest.py
@@ -1,0 +1,7 @@
+import tensorly as tl
+
+
+def pytest_ignore_collect():
+    if tl.get_backend() != "numpy":
+        return True
+    return False

--- a/src/matcouply/decomposition.py
+++ b/src/matcouply/decomposition.py
@@ -345,7 +345,7 @@ def admm_update_C(
 
 
 def _root_sum_squared_list(x_list):
-    return tl.sqrt(sum(tl.sum(x ** 2) for x in x_list))
+    return np.sqrt(tl.to_numpy(sum(tl.sum(x ** 2) for x in x_list)))
 
 
 def compute_feasibility_gaps(cmf, regs, A_aux_list, B_aux_list, C_aux_list):
@@ -449,7 +449,7 @@ def _cmf_reconstruction_error(matrices, cmf, norm_matrices=None, intermediate_A_
         norm_cmf_sq = sum(tl.sum(tl.diag(ai) @ cross_products[i] @ tl.diag(ai)) for i, ai in enumerate(A))
 
     # Threshold to handle roundoff errors with very small error
-    return tl.sqrt(max(0, norm_X_sq - 2 * inner_product + norm_cmf_sq))
+    return np.sqrt(tl.to_numpy(max(0, norm_X_sq - 2 * inner_product + norm_cmf_sq)))
 
 
 def _listify(input_value, param_name):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,7 +11,8 @@ from tensorly.testing import assert_array_equal
 from matcouply import data
 from matcouply.coupled_matrices import CoupledMatrixFactorization
 from matcouply.decomposition import _cmf_reconstruction_error
-from matcouply.testing import assert_allclose
+
+from .utils import RTOL_SCALE
 
 
 def test_get_simple_simulated_data():
@@ -42,7 +43,7 @@ def test_get_simple_simulated_data():
     simulated_data_noise_02, cmf_noise_02 = data.get_simple_simulated_data(noise_level=0.2, random_state=2)
     data_strength = tl.norm(cmf_noise_02.to_tensor())
     error = _cmf_reconstruction_error(simulated_data_noise_02, cmf_noise_02) / data_strength
-    assert error == pytest.approx(0.2)
+    assert error == pytest.approx(0.2, rel=1e-6*RTOL_SCALE)
 
 
 def test_get_bike_data():


### PR DESCRIPTION
The SSE of a CMF decomposition can be computed efficiently as 

$$ || \mathbf{X}^{(i)} - \mathbf{B}^{(i)} \mathbf{D}^{(i)} \mathbf{C}^\mathsf{T} ||^2 = ||\mathbf{X}^{(i)}||^2 - 2\text{Tr} ({\mathbf{X}^{(i)}}^\mathsf{T} \mathbf{B}^{(i)} \mathbf{D}^{(i)} \mathbf{C}^\mathsf{T} ) + ||\mathbf{B}^{(i)} \mathbf{D}^{(i)} \mathbf{C}^\mathsf{T}||^2, $$

which is equal to

$$ || \mathbf{X}^{(i)} - \mathbf{B}^{(i)} \mathbf{D}^{(i)} \mathbf{C}^\mathsf{T} ||^2 = ||\mathbf{X}^{(i)}||^2 - 2\text{Tr} (\mathbf{C}^\mathsf{T} {\mathbf{X}^{(i)}}^\mathsf{T} \mathbf{B}^{(i)} \mathbf{D}^{(i)} ) + ||\mathbf{B}^{(i)} \mathbf{D}^{(i)} \mathbf{C}^\mathsf{T}||^2. $$

We can evaluate this expression efficiently, since we to update $\mathbf{D}^{(i)}$ must compute both $\mathbf{C}^\mathsf{T} {\mathbf{X}^{(i)}}^\mathsf{T} \mathbf{B}^{(i)}$ and ${\mathbf{B}^{(i)}}^\mathsf{T}\mathbf{B}^{(i)} * \mathbf{C}^\mathsf{T}\mathbf{C}$. If we update $\mathbf{D}^{(i)}$ after $\mathbf{B}^{(i)}$ and $\mathbf{C}$, then we can cache these terms to compute $2\text{Tr} (\mathbf{C}^\mathsf{T} {\mathbf{X}^{(i)}}^\mathsf{T} \mathbf{B}^{(i)} \mathbf{D}^{(i)} )$ and $|\mathbf{B}^{(i)} \mathbf{D}^{(i)} \mathbf{C}^\mathsf{T}||^2$ efficiently.